### PR TITLE
Add realtime GPT chat comparison UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,7 @@
-const REFRESH_INTERVAL_MS = 1000;
+const REALTIME_MODEL = 'gpt-4o-realtime-preview-2024-12-17';
+const REALTIME_BASE_URL = 'https://api.openai.com/v1/realtime';
+const REALTIME_WS_PATH = '/openai/agents/realtime/ws';
+const REALTIME_EPHEMERAL_PATH = '/openai/agents/realtime/ephemeral-token';
 
 function createLatencyTracker(root) {
   const statusEl = root.querySelector('.status');
@@ -29,141 +32,541 @@ function createLatencyTracker(root) {
   };
 }
 
-async function startWebSocketTest(tracker) {
-  tracker.reset();
-  tracker.setStatus('Connecting…');
+const ROLE_LABELS = {
+  user: 'You',
+  'gpt-ws': 'GPT (WebSocket)',
+  'gpt-webrtc': 'GPT (WebRTC)',
+  error: 'Error',
+};
 
-  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const ws = new WebSocket(
-    `${protocol}//${location.host}/openai/agents/realtime/ws`
-  );
+function appendMessage(container, role, text = '') {
+  const wrapper = document.createElement('div');
+  wrapper.className = `message ${role}`;
 
-  const inflight = new Map();
+  const roleEl = document.createElement('span');
+  roleEl.className = 'message-role';
+  roleEl.textContent = ROLE_LABELS[role] ?? role;
 
-  ws.addEventListener('open', () => {
-    tracker.setStatus('Connected');
-    const interval = setInterval(() => {
-      const id = crypto.randomUUID();
-      const clientSentTs = performance.now();
-      inflight.set(id, clientSentTs);
-      ws.send(
-        JSON.stringify({
-          type: 'ping',
-          id,
-          clientSentTs,
-        })
-      );
-    }, REFRESH_INTERVAL_MS);
+  const textEl = document.createElement('span');
+  textEl.className = 'message-text';
+  textEl.textContent = text;
 
-    ws.addEventListener('close', () => {
-      clearInterval(interval);
-      tracker.setStatus('Closed');
-    });
-  });
+  wrapper.append(roleEl, textEl);
+  container.appendChild(wrapper);
+  container.scrollTop = container.scrollHeight;
 
-  ws.addEventListener('message', (event) => {
-    try {
-      const payload = JSON.parse(event.data);
-      if (payload.type === 'pong' && payload.id && inflight.has(payload.id)) {
-        const start = inflight.get(payload.id);
-        inflight.delete(payload.id);
-        tracker.recordLatency(performance.now() - start);
-      }
-    } catch (error) {
-      console.error('WebSocket message parse error', error);
-    }
-  });
-
-  ws.addEventListener('error', (error) => {
-    console.error('WebSocket error', error);
-    tracker.setStatus('Error (see console)');
-  });
+  return { wrapper, textEl };
 }
 
-async function startWebRTCTest(tracker) {
-  tracker.reset();
-  tracker.setStatus('Connecting…');
+function textFromContent(content) {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map((item) => textFromContent(item)).join('');
+  }
+  if (typeof content === 'object') {
+    if (typeof content.text === 'string') return content.text;
+    if (Array.isArray(content.output_text)) {
+      return content.output_text.join('');
+    }
+    if (Array.isArray(content.content)) {
+      return textFromContent(content.content);
+    }
+    if (content.delta) {
+      return textFromContent(content.delta);
+    }
+  }
+  return '';
+}
 
-  const peerConnection = new RTCPeerConnection();
-  const dataChannel = peerConnection.createDataChannel('latency');
+function extractDeltaText(event) {
+  if (!event) return '';
+  if (event.delta) {
+    if (typeof event.delta.text === 'string') {
+      return event.delta.text;
+    }
+    if (Array.isArray(event.delta.output_text)) {
+      return event.delta.output_text.join('');
+    }
+    if (Array.isArray(event.delta.content) || typeof event.delta.content === 'object') {
+      return textFromContent(event.delta.content);
+    }
+  }
+  if (event.item && event.item.content) {
+    return textFromContent(event.item.content);
+  }
+  return '';
+}
 
-  const inflight = new Map();
+function extractCompletedText(event, fallback = '') {
+  if (!event) return fallback;
+  const { response } = event;
+  if (response) {
+    if (Array.isArray(response.output_text)) {
+      return response.output_text.join('');
+    }
+    if (Array.isArray(response.output)) {
+      return textFromContent(response.output);
+    }
+    if (Array.isArray(response.content)) {
+      return textFromContent(response.content);
+    }
+  }
+  return fallback;
+}
 
-  dataChannel.addEventListener('open', () => {
-    tracker.setStatus('Connected');
-    const interval = setInterval(() => {
-      if (dataChannel.readyState !== 'open') {
-        clearInterval(interval);
-        return;
-      }
-      const id = crypto.randomUUID();
-      const clientSentTs = performance.now();
-      inflight.set(id, clientSentTs);
-      dataChannel.send(
-        JSON.stringify({
-          type: 'ping',
-          id,
-          clientSentTs,
-        })
-      );
-    }, REFRESH_INTERVAL_MS);
+function createTransportState({ id, tracker, messagesEl }) {
+  return {
+    id,
+    tracker,
+    messagesEl,
+    isReady: false,
+    connection: null,
+    pendingMessages: new Map(),
+    responsesById: new Map(),
+  };
+}
 
-    dataChannel.addEventListener('close', () => {
-      clearInterval(interval);
-      tracker.setStatus('Closed');
-    });
+function ensureResponseEntry(state, event) {
+  const response = event?.response;
+  if (!response?.id) {
+    return null;
+  }
+  let entry = state.responsesById.get(response.id);
+  if (!entry) {
+    const clientMessageId = response.metadata?.client_message_id;
+    const { textEl } = appendMessage(
+      state.messagesEl,
+      state.id === 'ws' ? 'gpt-ws' : 'gpt-webrtc'
+    );
+    entry = {
+      clientMessageId,
+      text: '',
+      textEl,
+    };
+    state.responsesById.set(response.id, entry);
+  } else if (!entry.clientMessageId && response.metadata?.client_message_id) {
+    entry.clientMessageId = response.metadata.client_message_id;
+  }
+  return entry;
+}
+
+function handleRealtimeEvent(state, event) {
+  if (!event || typeof event !== 'object') {
+    return;
+  }
+
+  if (event.type === 'error') {
+    const message =
+      event.error?.message || event.message || 'Unknown realtime error';
+    appendMessage(state.messagesEl, 'error', message);
+    state.tracker.setStatus('Error');
+    return;
+  }
+
+  if (event.type === 'server.status') {
+    if (typeof event.status === 'string') {
+      state.tracker.setStatus(event.status);
+    }
+    return;
+  }
+
+  const entry = ensureResponseEntry(state, event);
+  if (!entry) {
+    return;
+  }
+
+  if (event.type === 'response.delta' || event.type === 'response.output_text.delta') {
+    const fragment = extractDeltaText(event);
+    if (fragment) {
+      entry.text += fragment;
+      entry.textEl.textContent = entry.text;
+    }
+  } else if (event.type === 'response.completed') {
+    const finalText = extractCompletedText(event, entry.text);
+    entry.text = finalText;
+    entry.textEl.textContent = finalText;
+    if (entry.clientMessageId && state.pendingMessages.has(entry.clientMessageId)) {
+      const started = state.pendingMessages.get(entry.clientMessageId).start;
+      state.tracker.recordLatency(performance.now() - started);
+      state.pendingMessages.delete(entry.clientMessageId);
+    }
+    state.responsesById.delete(event.response.id);
+  } else if (event.type === 'response.error') {
+    const message =
+      event.error?.message || 'The model failed to generate a response.';
+    appendMessage(state.messagesEl, 'error', message);
+    if (entry.clientMessageId && state.pendingMessages.has(entry.clientMessageId)) {
+      state.pendingMessages.delete(entry.clientMessageId);
+    }
+    state.responsesById.delete(event.response.id);
+  }
+}
+
+function buildResponseCreateEvent(text, clientMessageId) {
+  return {
+    type: 'response.create',
+    response: {
+      metadata: {
+        client_message_id: clientMessageId,
+      },
+      input: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_text',
+              text,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+const startButton = document.querySelector('#start');
+const messageForm = document.querySelector('#message-form');
+const messageInput = document.querySelector('#message');
+const sendButton = document.querySelector('#send');
+
+const wsTracker = createLatencyTracker(document.querySelector('#ws-result'));
+const webrtcTracker = createLatencyTracker(
+  document.querySelector('#webrtc-result')
+);
+
+const wsMessagesEl = document.querySelector('#ws-result .messages');
+const webrtcMessagesEl = document.querySelector('#webrtc-result .messages');
+
+const wsState = createTransportState({
+  id: 'ws',
+  tracker: wsTracker,
+  messagesEl: wsMessagesEl,
+});
+const webrtcState = createTransportState({
+  id: 'webrtc',
+  tracker: webrtcTracker,
+  messagesEl: webrtcMessagesEl,
+});
+
+let hasAttemptedConnection = false;
+
+function updateSendControls() {
+  const ready = wsState.isReady || webrtcState.isReady;
+  messageInput.disabled = !ready;
+  sendButton.disabled = !ready;
+}
+
+function updateStartButton() {
+  const connecting =
+    (wsState.connection && !wsState.isReady) ||
+    (webrtcState.connection && !webrtcState.isReady);
+
+  if (wsState.isReady || webrtcState.isReady) {
+    startButton.textContent = 'Connected';
+    startButton.disabled = true;
+  } else if (connecting) {
+    startButton.textContent = 'Connecting…';
+    startButton.disabled = true;
+  } else {
+    startButton.textContent = hasAttemptedConnection ? 'Reconnect' : 'Connect';
+    startButton.disabled = false;
+  }
+}
+
+async function parseEventData(data) {
+  if (typeof data === 'string') {
+    return JSON.parse(data);
+  }
+  if (data instanceof Blob) {
+    return JSON.parse(await data.text());
+  }
+  const decoder = new TextDecoder();
+  if (data instanceof ArrayBuffer) {
+    return JSON.parse(decoder.decode(data));
+  }
+  if (ArrayBuffer.isView(data)) {
+    return JSON.parse(decoder.decode(data));
+  }
+  throw new Error('Unsupported event data type');
+}
+
+function startWebSocketTransport() {
+  wsTracker.reset();
+  wsTracker.setStatus('Connecting…');
+
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const socket = new WebSocket(`${protocol}//${location.host}${REALTIME_WS_PATH}`);
+  wsState.connection = socket;
+  updateStartButton();
+
+  const queue = [];
+
+  socket.addEventListener('open', () => {
+    wsState.isReady = true;
+    wsTracker.setStatus('Connected');
+    updateSendControls();
+    updateStartButton();
+    while (queue.length && socket.readyState === WebSocket.OPEN) {
+      socket.send(queue.shift());
+    }
   });
 
-  dataChannel.addEventListener('message', (event) => {
+  socket.addEventListener('message', async (event) => {
     try {
-      const payload = JSON.parse(event.data);
-      if (payload.type === 'pong' && payload.id && inflight.has(payload.id)) {
-        const start = inflight.get(payload.id);
-        inflight.delete(payload.id);
-        tracker.recordLatency(performance.now() - start);
-      }
+      const payload = await parseEventData(event.data);
+      handleRealtimeEvent(wsState, payload);
     } catch (error) {
-      console.error('Data channel message parse error', error);
+      console.error('Failed to parse WebSocket payload', error);
     }
+  });
+
+  socket.addEventListener('close', () => {
+    wsState.isReady = false;
+    wsState.connection = null;
+    wsState.send = undefined;
+    wsState.pendingMessages.clear();
+    updateSendControls();
+    if (wsTracker) {
+      wsTracker.setStatus('Closed');
+    }
+    updateStartButton();
+  });
+
+  socket.addEventListener('error', (error) => {
+    console.error('WebSocket transport error', error);
+    wsTracker.setStatus('Error (see console)');
+    updateStartButton();
+  });
+
+  wsState.send = (text) => {
+    if (!socket || socket.readyState === WebSocket.CLOSED) {
+      return false;
+    }
+    const message = text.trim();
+    if (!message) {
+      return false;
+    }
+    const clientMessageId = crypto.randomUUID();
+    const payload = JSON.stringify(buildResponseCreateEvent(message, clientMessageId));
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(payload);
+    } else if (socket.readyState === WebSocket.CONNECTING) {
+      queue.push(payload);
+    } else {
+      return false;
+    }
+    wsState.pendingMessages.set(clientMessageId, {
+      start: performance.now(),
+    });
+    appendMessage(wsState.messagesEl, 'user', message);
+    return true;
+  };
+}
+
+async function startWebRTCTransport() {
+  webrtcTracker.reset();
+  webrtcTracker.setStatus('Fetching token…');
+
+  let token;
+  try {
+    const response = await fetch(REALTIME_EPHEMERAL_PATH, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Failed to obtain ephemeral key (${response.status}): ${errorText}`
+      );
+    }
+    const data = await response.json();
+    token = data?.client_secret?.value || data?.client_secret;
+    if (!token) {
+      throw new Error('Ephemeral key response did not include a client secret');
+    }
+  } catch (error) {
+    console.error('Failed to fetch ephemeral key', error);
+    appendMessage(
+      webrtcState.messagesEl,
+      'error',
+      error.message || 'Failed to fetch ephemeral key'
+    );
+    webrtcTracker.setStatus('Error (token)');
+    updateStartButton();
+    return;
+  }
+
+  const peerConnection = new RTCPeerConnection();
+  webrtcState.connection = peerConnection;
+  updateStartButton();
+
+  const dataChannel = peerConnection.createDataChannel('oai-events');
+  webrtcState.dataChannel = dataChannel;
+
+  dataChannel.addEventListener('open', () => {
+    webrtcState.isReady = true;
+    webrtcTracker.setStatus('Connected');
+    updateSendControls();
+    updateStartButton();
+  });
+
+  dataChannel.addEventListener('message', async (event) => {
+    try {
+      const payload = await parseEventData(event.data);
+      handleRealtimeEvent(webrtcState, payload);
+    } catch (error) {
+      console.error('Failed to parse data channel payload', error);
+    }
+  });
+
+  dataChannel.addEventListener('close', () => {
+    webrtcState.isReady = false;
+    webrtcState.dataChannel = null;
+    webrtcState.connection = null;
+    webrtcState.send = undefined;
+    webrtcState.pendingMessages.clear();
+    try {
+      peerConnection.close();
+    } catch (error) {
+      console.warn('Error closing peer connection', error);
+    }
+    updateSendControls();
+    webrtcTracker.setStatus('Closed');
+    updateStartButton();
   });
 
   dataChannel.addEventListener('error', (error) => {
     console.error('Data channel error', error);
-    tracker.setStatus('Error (see console)');
+    webrtcTracker.setStatus('Error (see console)');
+    updateStartButton();
   });
 
   try {
     const offer = await peerConnection.createOffer();
     await peerConnection.setLocalDescription(offer);
 
-    const response = await fetch('/openai/agents/realtime/webrtc-offer', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(peerConnection.localDescription),
+    await new Promise((resolve) => {
+      if (peerConnection.iceGatheringState === 'complete') {
+        resolve();
+        return;
+      }
+      const checkState = () => {
+        if (peerConnection.iceGatheringState === 'complete') {
+          peerConnection.removeEventListener('icegatheringstatechange', checkState);
+          resolve();
+        }
+      };
+      peerConnection.addEventListener('icegatheringstatechange', checkState);
+      setTimeout(() => {
+        peerConnection.removeEventListener('icegatheringstatechange', checkState);
+        resolve();
+      }, 2000);
     });
 
-    if (!response.ok) {
-      throw new Error(`Failed to negotiate: ${response.status}`);
+    const offerSdp = peerConnection.localDescription?.sdp;
+    if (!offerSdp) {
+      throw new Error('Missing local SDP offer');
     }
 
-    const answer = await response.json();
-    await peerConnection.setRemoteDescription(answer);
-    tracker.setStatus('Waiting for channel…');
+    webrtcTracker.setStatus('Negotiating…');
+
+    const answerResponse = await fetch(
+      `${REALTIME_BASE_URL}?model=${encodeURIComponent(REALTIME_MODEL)}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/sdp',
+        },
+        body: offerSdp,
+      }
+    );
+
+    if (!answerResponse.ok) {
+      const errorText = await answerResponse.text();
+      throw new Error(
+        `OpenAI WebRTC negotiation failed (${answerResponse.status}): ${errorText}`
+      );
+    }
+
+    const answerSdp = await answerResponse.text();
+    await peerConnection.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+    webrtcTracker.setStatus('Waiting for channel…');
   } catch (error) {
-    console.error('WebRTC setup error', error);
-    tracker.setStatus('Error (see console)');
+    console.error('WebRTC negotiation failed', error);
+    appendMessage(
+      webrtcState.messagesEl,
+      'error',
+      error.message || 'WebRTC negotiation failed'
+    );
+    webrtcTracker.setStatus('Error (see console)');
+    peerConnection.close();
+    webrtcState.connection = null;
+    webrtcState.dataChannel = null;
+    webrtcState.send = undefined;
+    webrtcState.pendingMessages.clear();
+    updateSendControls();
+    updateStartButton();
+    return;
   }
+
+  webrtcState.send = (text) => {
+    const channel = webrtcState.dataChannel;
+    if (!channel || channel.readyState !== 'open') {
+      return false;
+    }
+    const message = text.trim();
+    if (!message) {
+      return false;
+    }
+    const clientMessageId = crypto.randomUUID();
+    channel.send(
+      JSON.stringify(buildResponseCreateEvent(message, clientMessageId))
+    );
+    webrtcState.pendingMessages.set(clientMessageId, {
+      start: performance.now(),
+    });
+    appendMessage(webrtcState.messagesEl, 'user', message);
+    return true;
+  };
 }
 
-const startButton = document.querySelector('#start');
-const wsTracker = createLatencyTracker(document.querySelector('#ws-result'));
-const webrtcTracker = createLatencyTracker(
-  document.querySelector('#webrtc-result')
-);
-
 startButton.addEventListener('click', () => {
-  startWebSocketTest(wsTracker);
-  startWebRTCTest(webrtcTracker);
   startButton.disabled = true;
-  startButton.textContent = 'Testing…';
+  hasAttemptedConnection = true;
+  startButton.textContent = 'Connecting…';
+  startWebSocketTransport();
+  startWebRTCTransport();
+  updateStartButton();
 });
+
+messageForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const text = messageInput.value.trim();
+  if (!text) {
+    return;
+  }
+
+  const sentViaWS = wsState.send ? wsState.send(text) : false;
+  const sentViaWebRTC = webrtcState.send ? webrtcState.send(text) : false;
+
+  if (!sentViaWS && !sentViaWebRTC) {
+    appendMessage(
+      wsState.messagesEl,
+      'error',
+      'Unable to send message. Please ensure a transport is connected.'
+    );
+    appendMessage(
+      webrtcState.messagesEl,
+      'error',
+      'Unable to send message. Please ensure a transport is connected.'
+    );
+    return;
+  }
+
+  messageInput.value = '';
+  messageInput.focus();
+});
+
+updateSendControls();
+updateStartButton();

--- a/public/index.html
+++ b/public/index.html
@@ -3,20 +3,46 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WebRTC vs WebSocket Latency Lab</title>
+    <title>GPT Realtime Latency Lab</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <main>
-      <h1>WebRTC vs WebSocket Latency Lab</h1>
+      <h1>GPT Realtime Latency Lab</h1>
       <p>
-        Use this page to compare the round-trip latency of messages sent through a
-        WebSocket connection and a WebRTC data channel. Click
-        <strong>Start test</strong> to open both transports and watch the live
-        metrics update.
+        Click <strong>Connect</strong> to open both a WebSocket bridge and a WebRTC
+        data channel to OpenAI's Realtime API. Once connected, type a message and
+        send it to talk with GPT. Each transport reports the round-trip latency
+        between sending your request and receiving the model's completed reply.
       </p>
 
-      <button id="start">Start test</button>
+      <p class="api-note">
+        The demo server needs <code>OPENAI_API_KEY</code> in its environment to
+        proxy requests to OpenAI. Without it, the transports will fail with a
+        descriptive error.
+      </p>
+
+      <button id="start">Connect</button>
+
+      <form id="message-form" class="message-form">
+        <label for="message">Send a message to GPT once either transport is ready:</label>
+        <div class="message-controls">
+          <input
+            id="message"
+            name="message"
+            type="text"
+            placeholder="Ask GPT something…"
+            autocomplete="off"
+            required
+            disabled
+          />
+          <button id="send" type="submit" disabled>Send</button>
+        </div>
+        <p class="hint">
+          Your prompt is dispatched to both transports simultaneously so you can
+          compare their responses and latency.
+        </p>
+      </form>
 
       <section class="results" id="ws-result">
         <h2>WebSocket</h2>
@@ -38,6 +64,10 @@
             <dd class="samples">0</dd>
           </div>
         </dl>
+        <div class="chat">
+          <h3>Conversation</h3>
+          <div class="messages" aria-live="polite"></div>
+        </div>
       </section>
 
       <section class="results" id="webrtc-result">
@@ -60,23 +90,29 @@
             <dd class="samples">0</dd>
           </div>
         </dl>
+        <div class="chat">
+          <h3>Conversation</h3>
+          <div class="messages" aria-live="polite"></div>
+        </div>
       </section>
 
       <section class="notes">
         <h2>How it works</h2>
         <ol>
           <li>
-            The server offers both a WebSocket endpoint and a WebRTC peer that
-            echoes any JSON payload tagged as a latency <code>ping</code>.
+            The server proxies WebSocket connections to OpenAI's
+            <code>/v1/realtime</code> endpoint and can mint ephemeral keys for
+            browser-side WebRTC sessions.
           </li>
           <li>
-            The page opens both transports, sends timestamped payloads once per
-            second, and computes round-trip latency using
-            <code>performance.now()</code>.
+            When you send a message, both transports issue identical
+            <code>response.create</code> events so GPT receives the same prompt
+            twice.
           </li>
           <li>
-            Because both transports share the same host and echo logic, the
-            numbers highlight the protocol differences rather than app logic.
+            The page timestamps each request and records the time until GPT
+            signals the response is complete, updating the latency dashboard in
+            real time.
           </li>
         </ol>
       </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,15 +14,26 @@ main {
   max-width: 960px;
   margin: 0 auto;
   padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 h1,
-h2 {
+h2,
+h3 {
   font-weight: 700;
 }
 
 p {
-  max-width: 60ch;
+  max-width: 65ch;
+}
+
+.api-note {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 118, 110, 0.15);
+  border: 1px solid rgba(15, 118, 110, 0.2);
 }
 
 button {
@@ -49,12 +60,49 @@ button:disabled {
   cursor: default;
 }
 
-.results {
-  margin-top: 2rem;
-  padding: 1.5rem;
+.message-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
   border-radius: 1rem;
   background: rgba(79, 70, 229, 0.08);
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.12);
+}
+
+.message-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.message-controls input[type='text'] {
+  flex: 1 1 260px;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(79, 70, 229, 0.35);
+  font-size: 1rem;
+}
+
+.message-controls input[type='text']:disabled {
+  background: rgba(255, 255, 255, 0.6);
+  color: rgba(17, 24, 39, 0.6);
+}
+
+.hint {
+  margin: 0;
+  color: #4c1d95;
+  font-size: 0.95rem;
+}
+
+.results {
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(79, 70, 229, 0.08);
   box-shadow: 0 20px 40px rgba(79, 70, 229, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
 .results dl {
@@ -74,8 +122,59 @@ button:disabled {
   font-size: 1.125rem;
 }
 
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.messages {
+  min-height: 140px;
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 1px 4px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.95rem;
+}
+
+.message-role {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #4f46e5;
+}
+
+.message-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message.user .message-role {
+  color: #0f766e;
+}
+
+.message.gpt-webrtc .message-role {
+  color: #7c3aed;
+}
+
+.message.error .message-role {
+  color: #b91c1c;
+}
+
 .notes {
-  margin-top: 3rem;
+  margin-top: 1rem;
   padding: 1.5rem;
   border-radius: 1rem;
   background: rgba(15, 118, 110, 0.1);
@@ -83,4 +182,19 @@ button:disabled {
 
 .notes li + li {
   margin-top: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .message-controls {
+    flex-direction: column;
+  }
+
+  .message-controls input[type='text'] {
+    flex: 1 1 auto;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the latency ping dashboard with GPT realtime chat controls that stream replies over both WebSocket and WebRTC while tracking latency
- refresh the page styling to support the new chat interface and transport status messaging
- proxy websocket traffic to OpenAI Realtime, expose an endpoint for WebRTC ephemeral keys, and document the required API configuration

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e4e526d1988326bad99285447ea952