### PR TITLE
改善對話區顯示 WebSocket 與 WebRTC 訊息

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -73,8 +73,11 @@
                 :class="['message', item.role]"
               >
                 <span class="message-role">{{ roleLabel(item.role) }}</span>
-                <span class="message-text">{{ item.text }}</span>
+                <div class="message-bubble">
+                  <p class="message-text">{{ item.text || '（等待回覆…）' }}</p>
+                </div>
               </div>
+              <p v-if="!ws.messages.length" class="messages-empty">尚未傳送任何訊息。</p>
             </div>
           </div>
         </section>
@@ -108,8 +111,11 @@
                 :class="['message', item.role]"
               >
                 <span class="message-role">{{ roleLabel(item.role) }}</span>
-                <span class="message-text">{{ item.text }}</span>
+                <div class="message-bubble">
+                  <p class="message-text">{{ item.text || '（等待回覆…）' }}</p>
+                </div>
               </div>
+              <p v-if="!webrtc.messages.length" class="messages-empty">尚未傳送任何訊息。</p>
             </div>
           </div>
         </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -137,7 +137,7 @@ button:disabled {
 
 .messages {
   min-height: 140px;
-  max-height: 280px;
+  max-height: 320px;
   overflow-y: auto;
   padding: 1rem;
   border-radius: 1rem;
@@ -148,36 +148,75 @@ button:disabled {
   gap: 0.75rem;
 }
 
+.messages-empty {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 .message {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.35rem;
   font-size: 0.95rem;
+  max-width: min(520px, 85%);
+}
+
+.message.user {
+  margin-left: auto;
+  align-items: flex-end;
 }
 
 .message-role {
   font-size: 0.8rem;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   color: #4f46e5;
-}
-
-.message-text {
-  white-space: pre-wrap;
-  word-break: break-word;
+  text-transform: uppercase;
 }
 
 .message.user .message-role {
   color: #0f766e;
 }
 
+.message.gpt-ws .message-role,
 .message.gpt-webrtc .message-role {
   color: #7c3aed;
 }
 
 .message.error .message-role {
   color: #b91c1c;
+}
+
+.message-bubble {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(79, 70, 229, 0.1);
+  border: 1px solid rgba(79, 70, 229, 0.18);
+  color: #1f2937;
+  width: 100%;
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.15);
+}
+
+.message.user .message-bubble {
+  background: rgba(15, 118, 110, 0.12);
+  border-color: rgba(15, 118, 110, 0.2);
+  color: #064e3b;
+  box-shadow: 0 8px 18px rgba(15, 118, 110, 0.12);
+}
+
+.message.error .message-bubble {
+  background: rgba(185, 28, 28, 0.1);
+  border-color: rgba(185, 28, 28, 0.2);
+  color: #7f1d1d;
+  box-shadow: 0 8px 18px rgba(185, 28, 28, 0.1);
+}
+
+.message-text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .notes {


### PR DESCRIPTION
## Summary
- 為 WebSocket 與 WebRTC 對話區新增泡泡樣式，清楚區隔使用者與 GPT 訊息
- 加入空狀態與回覆載入中的提示字詞，確保雙通道都能顯示對話內容

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e5b48985f48326b27017ef9e357ab2