### PR TITLE
為即時語音模式補齊語音參數設定

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,4 +1,8 @@
 const request = require('supertest');
+const {
+  DEFAULT_REALTIME_MODEL,
+  DEFAULT_REALTIME_VOICE,
+} = require('../src/config/constants');
 const { createRealtimeServer, REALTIME_EPHEMERAL_PATH } = require('../server');
 
 describe('createRealtimeServer', () => {
@@ -40,6 +44,12 @@ describe('createRealtimeServer', () => {
       'https://api.openai.com/v1/realtime/sessions',
       expect.objectContaining({ method: 'POST' })
     );
+    const [, fetchOptions] = fakeFetch.mock.calls[0];
+    const requestBody = JSON.parse(fetchOptions.body);
+    expect(requestBody).toEqual({
+      model: DEFAULT_REALTIME_MODEL,
+      voice: DEFAULT_REALTIME_VOICE,
+    });
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
       id: 'session-id',

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -8,6 +8,7 @@ const DEFAULT_PORT = Number(process.env.PORT) || 3000;
 const DEFAULT_API_KEY = process.env.OPENAI_API_KEY || null;
 const DEFAULT_REALTIME_MODEL =
   process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview-2024-12-17';
+const DEFAULT_REALTIME_VOICE = process.env.OPENAI_REALTIME_VOICE || 'verse';
 const OPENAI_REALTIME_BASE_URL = 'https://api.openai.com/v1/realtime';
 
 const REALTIME_PATH = '/openai/agents/realtime';
@@ -20,6 +21,7 @@ module.exports = {
   DEFAULT_PORT,
   DEFAULT_API_KEY,
   DEFAULT_REALTIME_MODEL,
+  DEFAULT_REALTIME_VOICE,
   OPENAI_REALTIME_BASE_URL,
   REALTIME_PATH,
   REALTIME_WS_PATH,

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -2,6 +2,7 @@ const {
   DEFAULT_PORT,
   DEFAULT_API_KEY,
   DEFAULT_REALTIME_MODEL,
+  DEFAULT_REALTIME_VOICE,
   OPENAI_REALTIME_BASE_URL,
   DEFAULT_PUBLIC_DIRECTORY,
 } = require('./constants');
@@ -18,6 +19,7 @@ function buildConfig(options = {}) {
     port = DEFAULT_PORT,
     apiKey = DEFAULT_API_KEY,
     realtimeModel = DEFAULT_REALTIME_MODEL,
+    realtimeVoice = DEFAULT_REALTIME_VOICE,
     realtimeBaseUrl = OPENAI_REALTIME_BASE_URL,
     fetchImpl = global.fetch,
     publicDirectory = DEFAULT_PUBLIC_DIRECTORY,
@@ -27,6 +29,7 @@ function buildConfig(options = {}) {
     port,
     apiKey,
     realtimeModel,
+    realtimeVoice,
     realtimeBaseUrl,
     fetchImpl: ensureFetch(fetchImpl),
     publicDirectory,

--- a/src/routes/registerEphemeralTokenRoute.js
+++ b/src/routes/registerEphemeralTokenRoute.js
@@ -1,7 +1,8 @@
 const { REALTIME_EPHEMERAL_PATH } = require('../config/constants');
 
 function registerEphemeralTokenRoute(app, dependencies) {
-  const { apiKey, realtimeModel, realtimeBaseUrl, fetchImpl } = dependencies;
+  const { apiKey, realtimeModel, realtimeVoice, realtimeBaseUrl, fetchImpl } =
+    dependencies;
 
   app.post(REALTIME_EPHEMERAL_PATH, async (_req, res) => {
     if (!apiKey) {
@@ -18,7 +19,7 @@ function registerEphemeralTokenRoute(app, dependencies) {
         },
         body: JSON.stringify({
           model: realtimeModel,
-          voice: 'verse',
+          voice: realtimeVoice,
         }),
       });
 

--- a/src/server/realtimeServer.js
+++ b/src/server/realtimeServer.js
@@ -18,6 +18,7 @@ function createRealtimeServer(options = {}) {
   registerEphemeralTokenRoute(app, {
     apiKey: config.apiKey,
     realtimeModel: config.realtimeModel,
+    realtimeVoice: config.realtimeVoice,
     realtimeBaseUrl: config.realtimeBaseUrl,
     fetchImpl: config.fetchImpl,
   });
@@ -28,6 +29,7 @@ function createRealtimeServer(options = {}) {
   const handleConnection = createRealtimeWebSocketHandler({
     apiKey: config.apiKey,
     realtimeModel: config.realtimeModel,
+    realtimeVoice: config.realtimeVoice,
     realtimeBaseUrl: config.realtimeBaseUrl,
   });
 

--- a/src/websocket/createRealtimeWebSocketHandler.js
+++ b/src/websocket/createRealtimeWebSocketHandler.js
@@ -1,7 +1,7 @@
 const { WebSocket } = require('ws');
 
 function createRealtimeWebSocketHandler(options) {
-  const { apiKey, realtimeModel, realtimeBaseUrl } = options;
+  const { apiKey, realtimeModel, realtimeVoice, realtimeBaseUrl } = options;
 
   return (clientSocket) => {
     console.log('WebSocket 用戶端已連線');
@@ -17,8 +17,13 @@ function createRealtimeWebSocketHandler(options) {
       return;
     }
 
-    const upstreamUrl = `${realtimeBaseUrl}?model=${encodeURIComponent(realtimeModel)}`;
-    const upstream = new WebSocket(upstreamUrl, {
+    const upstreamUrl = new URL(realtimeBaseUrl);
+    upstreamUrl.searchParams.set('model', realtimeModel);
+    if (realtimeVoice) {
+      upstreamUrl.searchParams.set('voice', realtimeVoice);
+    }
+
+    const upstream = new WebSocket(upstreamUrl.toString(), {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'OpenAI-Beta': 'realtime=v1',


### PR DESCRIPTION
## Summary
- 新增可設定的預設語音並串接至環境組態
- 將語音參數套用至短效金鑰端點與 WebSocket 連線
- 擴充伺服器測試以驗證語音參數已送至 OpenAI 服務

## Testing
- npm test -- --watch=false
- npm run format:check

------
https://chatgpt.com/codex/tasks/task_e_68e5cce8ca5c83268ff6a8f0c814ead5