### PR TITLE
Refactor realtime demo layout and strengthen realtime transports

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,9 +1,58 @@
+const EventEmitter = require('events');
 const request = require('supertest');
 const {
   DEFAULT_REALTIME_MODEL,
   DEFAULT_REALTIME_VOICE,
 } = require('../src/config/constants');
 const { createRealtimeServer, REALTIME_EPHEMERAL_PATH } = require('../server');
+const {
+  createRealtimeWebSocketHandler,
+} = require('../src/websocket/createRealtimeWebSocketHandler');
+
+class MockSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.sent = [];
+    this.closed = false;
+    this.readyState = MockSocket.CONNECTING;
+  }
+
+  send(payload) {
+    this.sent.push(payload);
+  }
+
+  close(code, reason) {
+    if (this.readyState === MockSocket.CLOSED) {
+      return;
+    }
+    this.closed = true;
+    this.readyState = MockSocket.CLOSED;
+    this.emit('close', code, reason);
+  }
+
+  triggerOpen() {
+    this.readyState = MockSocket.OPEN;
+    this.emit('open');
+  }
+
+  triggerMessage(payload) {
+    this.emit('message', payload);
+  }
+
+  triggerClose(code = 1000, reason = '') {
+    this.readyState = MockSocket.CLOSED;
+    this.emit('close', code, reason);
+  }
+
+  triggerError(error) {
+    this.emit('error', error);
+  }
+}
+
+MockSocket.CONNECTING = 0;
+MockSocket.OPEN = 1;
+MockSocket.CLOSING = 2;
+MockSocket.CLOSED = 3;
 
 describe('createRealtimeServer', () => {
   test('回報缺少金鑰的錯誤訊息', async () => {
@@ -64,5 +113,99 @@ describe('createRealtimeServer', () => {
         throw error;
       }
     }
+  });
+
+  test('上游回應錯誤時回報詳細訊息', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized',
+    });
+
+    const { app, server } = createRealtimeServer({
+      apiKey: 'test-key',
+      fetchImpl: fakeFetch,
+    });
+
+    const response = await request(app).post(REALTIME_EPHEMERAL_PATH);
+
+    expect(fakeFetch).toHaveBeenCalled();
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({
+      error: '建立短效會話失敗',
+      details: 'unauthorized',
+    });
+
+    try {
+      server.close();
+    } catch (error) {
+      if (error?.code !== 'ERR_SERVER_NOT_RUNNING') {
+        throw error;
+      }
+    }
+  });
+});
+
+describe('createRealtimeWebSocketHandler', () => {
+  test('缺少 API 金鑰時回傳錯誤並關閉連線', () => {
+    const handler = createRealtimeWebSocketHandler({
+      apiKey: null,
+      realtimeModel: 'test-model',
+      realtimeVoice: 'verse',
+      realtimeBaseUrl: 'wss://example',
+    });
+
+    const clientSocket = new MockSocket();
+    handler(clientSocket);
+
+    expect(clientSocket.sent).toHaveLength(1);
+    expect(JSON.parse(clientSocket.sent[0])).toEqual({
+      type: 'error',
+      error: { message: '伺服器缺少 OPENAI_API_KEY' },
+    });
+    expect(clientSocket.closed).toBe(true);
+  });
+
+  test('成功連線後會回傳狀態並轉發訊息', () => {
+    const upstreamSocket = new MockSocket();
+    const createUpstream = jest.fn(() => upstreamSocket);
+
+    const handler = createRealtimeWebSocketHandler({
+      apiKey: 'key',
+      realtimeModel: 'test-model',
+      realtimeVoice: 'verse',
+      realtimeBaseUrl: 'wss://example',
+      webSocketImpl: MockSocket,
+      createUpstream,
+    });
+
+    const clientSocket = new MockSocket();
+    clientSocket.readyState = MockSocket.OPEN;
+    handler(clientSocket);
+
+    expect(createUpstream).toHaveBeenCalledWith(
+      expect.stringContaining('model=test-model'),
+      expect.objectContaining({ headers: expect.any(Object) })
+    );
+
+    clientSocket.emit('message', 'queued-message');
+    expect(upstreamSocket.sent).toHaveLength(0);
+
+    upstreamSocket.triggerOpen();
+    expect(clientSocket.sent).toContainEqual(
+      expect.stringContaining('"type":"server.status"')
+    );
+    expect(upstreamSocket.sent).toContain('queued-message');
+
+    upstreamSocket.readyState = MockSocket.OPEN;
+    upstreamSocket.triggerMessage('server-payload');
+    expect(clientSocket.sent).toContain('server-payload');
+
+    upstreamSocket.triggerClose(4000, Buffer.from('bye'));
+    expect(clientSocket.closed).toBe(true);
+    const statusPayload = clientSocket.sent.find(
+      (item) => item.includes('"status"') && item.includes('bye')
+    );
+    expect(statusPayload).toBeTruthy();
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -4,126 +4,263 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GPT 即時延遲實驗室</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              surface: {
+                DEFAULT: '#0b1120',
+                muted: '#111c34',
+              },
+            },
+            fontFamily: {
+              sans: ['"Noto Sans TC"', '"Segoe UI"', 'system-ui', 'sans-serif'],
+            },
+          },
+        },
+      };
+    </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body>
-    <div id="app">
-      <main>
-        <h1>GPT 即時延遲實驗室</h1>
-        <p>
-          按下 <strong>連線</strong> 以前，請先選擇要使用的傳輸模式。成功連線後輸入訊息並
-          送出，就能透過所選模式與 GPT 對話並觀察往返延遲。每次只能有一種通話模式處於
-          連線狀態。
-        </p>
-
-        <p class="api-note">
-          範例伺服器需要在環境變數中設定 <code>OPENAI_API_KEY</code> 才能代理 前往
-          OpenAI。若缺少金鑰，選定的傳輸模式會回報明確的錯誤。
-        </p>
-
-        <section class="mode-selector">
-          <h2>選擇通話模式</h2>
-          <fieldset>
-            <legend class="visually-hidden">可用的連線模式</legend>
-            <div class="mode-options">
-              <label v-for="option in modeOptions" :key="option.id" class="mode-option">
-                <input
-                  type="radio"
-                  name="mode"
-                  :value="option.id"
-                  v-model="selectedMode"
-                />
-                <span class="mode-info">
-                  <span class="mode-name">{{ option.label }}</span>
-                  <span class="mode-description">{{ option.description }}</span>
-                </span>
-              </label>
+  <body class="bg-surface text-slate-100">
+    <div id="app" class="min-h-screen">
+      <div class="flex min-h-screen flex-col">
+        <header class="border-b border-slate-800/60 bg-slate-900/50 backdrop-blur">
+          <div
+            class="mx-auto flex w-full max-w-[1400px] flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between"
+          >
+            <div class="space-y-2">
+              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-sky-400">
+                Realtime Playground
+              </p>
+              <h1 class="text-3xl font-semibold tracking-tight">GPT 即時延遲實驗室</h1>
+              <p class="max-w-2xl text-sm text-slate-400">
+                按下
+                <strong class="font-semibold text-slate-100">連線</strong>
+                前先選擇傳輸模式。 成功建立連線後便能在同一個聊天面板中比較 WebSocket 與
+                WebRTC 的往返延遲。
+              </p>
             </div>
-          </fieldset>
-          <p class="hint">切換模式會立即結束目前的連線，需重新按下「連線」。</p>
-        </section>
-
-        <button id="start" type="button" @click="onStartClick" :disabled="startDisabled">
-          {{ startLabel }}
-        </button>
-
-        <form id="message-form" class="message-form" @submit.prevent="sendMessage">
-          <label for="message">{{ activeModeLabel }} 準備就緒後，傳訊給 GPT：</label>
-          <div class="message-controls">
-            <input
-              id="message"
-              ref="messageInputRef"
-              name="message"
-              type="text"
-              placeholder="問 GPT 一個問題…"
-              autocomplete="off"
-              required
-              v-model="message"
-              :disabled="!canSend"
-            />
-            <button id="send" type="submit" :disabled="!canSend">送出</button>
-          </div>
-          <p class="hint">訊息只會送往當前選定的模式，並記錄往返延遲。</p>
-        </form>
-
-        <section class="results" :id="`result-${activeTransport.id}`">
-          <h2>{{ activeModeLabel }}</h2>
-          <dl>
-            <div>
-              <dt>狀態</dt>
-              <dd class="status">{{ activeTransport.status }}</dd>
-            </div>
-            <div>
-              <dt>最新延遲</dt>
-              <dd class="latest">{{ activeTransport.latest }}</dd>
-            </div>
-            <div>
-              <dt>平均延遲</dt>
-              <dd class="average">{{ activeTransport.average }}</dd>
-            </div>
-            <div>
-              <dt>樣本數</dt>
-              <dd class="samples">{{ activeTransport.samples }}</dd>
-            </div>
-          </dl>
-          <div class="chat">
-            <h3>對話內容</h3>
-            <div class="messages" aria-live="polite">
-              <div
-                v-for="item in activeTransport.messages"
-                :key="item.id"
-                :class="['message', item.role]"
-              >
-                <span class="message-role">{{ roleLabel(item.role) }}</span>
-                <div class="message-bubble">
-                  <p class="message-text">{{ item.text || '（等待回覆…）' }}</p>
-                </div>
-              </div>
-              <p v-if="!activeTransport.messages.length" class="messages-empty">
-                尚未傳送任何訊息。
+            <div
+              class="rounded-2xl border border-slate-800/70 bg-slate-900/60 px-5 py-4 text-xs text-slate-400 shadow-lg shadow-slate-950/40"
+            >
+              <p>
+                範例伺服器需在環境變數中設定
+                <code class="font-mono text-slate-200">OPENAI_API_KEY</code>
+                才能代理請求；缺少金鑰時，所選模式會立即回報錯誤。
               </p>
             </div>
           </div>
-        </section>
+        </header>
 
-        <section class="notes">
-          <h2>運作流程</h2>
-          <ol>
-            <li>
-              伺服器會將 WebSocket 連線代理至 OpenAI 的
-              <code>/v1/realtime</code> 端點，並能簽發瀏覽器使用的 WebRTC 短效金鑰。
-            </li>
-            <li>
-              當你送出訊息時，所選模式會發送 <code>response.create</code>
-              事件，讓 GPT 收到你的提示。
-            </li>
-            <li>
-              頁面會記錄每次請求的時間點，直到 GPT 宣告回覆完成為止，並即時更新延遲
-              儀表板。
-            </li>
-          </ol>
-        </section>
-      </main>
+        <div class="mx-auto flex w-full max-w-[1400px] flex-1 flex-col lg:flex-row">
+          <aside
+            class="border-b border-slate-800/60 bg-slate-900/30 px-6 py-6 backdrop-blur lg:h-[calc(100vh-6rem)] lg:w-80 lg:border-b-0 lg:border-r lg:px-8 lg:py-10"
+          >
+            <div class="space-y-6">
+              <section class="space-y-4">
+                <h2 class="text-lg font-semibold text-slate-200">選擇通話模式</h2>
+                <fieldset class="space-y-4">
+                  <legend class="visually-hidden">可用的連線模式</legend>
+                  <div class="flex flex-col gap-3">
+                    <label
+                      v-for="option in modeOptions"
+                      :key="option.id"
+                      class="group flex cursor-pointer items-start gap-3 rounded-2xl border border-slate-800/70 bg-slate-900/40 px-4 py-3 text-left shadow-sm transition hover:border-sky-500/60 hover:bg-slate-900/60"
+                    >
+                      <input
+                        type="radio"
+                        name="mode"
+                        :value="option.id"
+                        v-model="selectedMode"
+                        class="mt-1 h-5 w-5 border-slate-600 text-sky-400 focus:ring-sky-500"
+                      />
+                      <span class="flex-1 space-y-1">
+                        <span class="block text-base font-medium text-slate-100"
+                          >{{ option.label }}</span
+                        >
+                        <span class="block text-sm text-slate-400"
+                          >{{ option.description }}</span
+                        >
+                      </span>
+                    </label>
+                  </div>
+                </fieldset>
+                <p
+                  class="rounded-xl border border-slate-800/70 bg-slate-900/40 px-4 py-3 text-xs text-slate-400"
+                >
+                  切換模式會立即結束目前的連線，需要重新按下「連線」。
+                </p>
+              </section>
+
+              <section class="space-y-3">
+                <h2 class="text-lg font-semibold text-slate-200">連線控制</h2>
+                <button
+                  id="start"
+                  type="button"
+                  class="flex w-full items-center justify-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold tracking-wide text-slate-950 shadow-lg shadow-sky-900/50 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300"
+                  @click="onStartClick"
+                  :disabled="startDisabled"
+                >
+                  {{ startLabel }}
+                </button>
+                <p class="text-xs leading-relaxed text-slate-400">
+                  {{ activeModeLabel }}
+                  會保持唯一通道。重新連線時會清除未完成的延遲樣本並重新建立連線。
+                </p>
+              </section>
+
+              <section class="space-y-3 text-sm text-slate-400">
+                <h2 class="text-lg font-semibold text-slate-200">操作提示</h2>
+                <ul class="space-y-2">
+                  <li class="flex gap-2">
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-sky-400"></span>
+                    <span
+                      >WebRTC
+                      需要麥克風權限才能傳輸即時語音；若拒絕權限，系統會自動改為僅接收。</span
+                    >
+                  </li>
+                  <li class="flex gap-2">
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
+                    <span
+                      >傳送訊息後可觀察最新延遲、平均延遲與樣本數，協助比較不同傳輸模式。</span
+                    >
+                  </li>
+                  <li class="flex gap-2">
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-rose-400"></span>
+                    <span>錯誤訊息會直接出現在聊天面板中，方便排除故障。</span>
+                  </li>
+                </ul>
+              </section>
+            </div>
+          </aside>
+
+          <main
+            class="flex-1 bg-slate-950/40 px-6 pb-10 pt-6 lg:h-[calc(100vh-6rem)] lg:overflow-hidden lg:px-10 lg:pb-14 lg:pt-10"
+          >
+            <section
+              class="grid gap-4 rounded-3xl border border-slate-800/60 bg-slate-900/30 p-6 shadow-inner shadow-slate-950/40 backdrop-blur lg:grid-cols-4"
+            >
+              <article class="stat-card">
+                <h3>狀態</h3>
+                <p class="stat-value">{{ activeTransport.status }}</p>
+              </article>
+              <article class="stat-card">
+                <h3>最新延遲</h3>
+                <p class="stat-value">{{ activeTransport.latest }}</p>
+              </article>
+              <article class="stat-card">
+                <h3>平均延遲</h3>
+                <p class="stat-value">{{ activeTransport.average }}</p>
+              </article>
+              <article class="stat-card">
+                <h3>樣本數</h3>
+                <p class="stat-value">{{ activeTransport.samples }}</p>
+              </article>
+            </section>
+
+            <section class="mt-6 flex h-full flex-col gap-6 lg:mt-8">
+              <div
+                class="flex flex-1 flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/50 shadow-xl shadow-slate-950/40"
+              >
+                <div
+                  class="flex flex-col gap-2 border-b border-slate-800/70 px-6 py-5 lg:flex-row lg:items-center lg:justify-between"
+                >
+                  <div>
+                    <h2 class="text-xl font-semibold text-slate-100">
+                      {{ activeModeLabel }} 聊天面板
+                    </h2>
+                    <p class="text-sm text-slate-400">
+                      所有訊息都會出現在這裡，方便直接比較兩種模式的輸出效果。
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="chat-scroll flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-6"
+                  aria-live="polite"
+                >
+                  <template v-if="activeTransport.messages.length">
+                    <div
+                      v-for="item in activeTransport.messages"
+                      :key="item.id"
+                      :class="messageContainerClass(item.role)"
+                    >
+                      <span class="message-role-label">{{ roleLabel(item.role) }}</span>
+                      <div :class="messageBubbleClass(item.role)">
+                        <p class="leading-relaxed">{{ item.text || '（等待回覆…）' }}</p>
+                      </div>
+                    </div>
+                  </template>
+                  <p
+                    v-else
+                    class="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/40 px-6 py-10 text-center text-sm text-slate-400"
+                  >
+                    尚未傳送任何訊息。請先建立連線並輸入訊息開始對話。
+                  </p>
+                </div>
+                <form
+                  id="message-form"
+                  class="border-t border-slate-800/70 bg-slate-950/40 px-6 py-5"
+                  @submit.prevent="sendMessage"
+                >
+                  <label for="message" class="sr-only"
+                    >{{ activeModeLabel }} 準備就緒後，傳訊給 GPT</label
+                  >
+                  <div class="flex flex-col gap-3 lg:flex-row lg:items-center">
+                    <input
+                      id="message"
+                      ref="messageInputRef"
+                      name="message"
+                      type="text"
+                      placeholder="問 GPT 一個問題…"
+                      autocomplete="off"
+                      required
+                      v-model="message"
+                      :disabled="!canSend"
+                      class="flex-1 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/50 disabled:cursor-not-allowed disabled:bg-slate-800/40 disabled:text-slate-500"
+                    />
+                    <button
+                      id="send"
+                      type="submit"
+                      :disabled="!canSend"
+                      class="flex items-center justify-center rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold tracking-wide text-slate-950 shadow-lg shadow-sky-900/40 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300"
+                    >
+                      送出
+                    </button>
+                  </div>
+                  <p class="mt-3 text-xs text-slate-500">
+                    訊息只會送往當前選定的模式，並會記錄自送出至回覆完成的往返延遲。
+                  </p>
+                </form>
+              </div>
+
+              <section
+                class="rounded-3xl border border-slate-800/60 bg-slate-900/40 p-6 text-sm text-slate-300 shadow-inner shadow-slate-950/40"
+              >
+                <h2 class="text-lg font-semibold text-slate-100">運作流程</h2>
+                <ol class="mt-4 space-y-3 list-decimal pl-6">
+                  <li>
+                    伺服器會將 WebSocket 連線代理至 OpenAI 的
+                    <code class="font-mono text-slate-200">/v1/realtime</code>
+                    端點，並能簽發瀏覽器使用的 WebRTC 短效金鑰。
+                  </li>
+                  <li>
+                    當你送出訊息時，所選模式會發送
+                    <code class="font-mono text-slate-200">response.create</code>
+                    事件，讓 GPT 收到你的提示並開始串流回覆。
+                  </li>
+                  <li>
+                    頁面會記錄每次請求的時間點，直到 GPT
+                    宣告回覆完成為止，並即時更新延遲儀表板。
+                  </li>
+                </ol>
+              </section>
+            </section>
+          </main>
+        </div>
+      </div>
     </div>
     <script src="app.js" type="module"></script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,40 +1,38 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
   font-family:
+    'Noto Sans TC',
+    'Segoe UI',
     system-ui,
     -apple-system,
     BlinkMacSystemFont,
-    'Segoe UI',
     sans-serif;
-  line-height: 1.5;
+  background-color: #020617;
+  line-height: 1.6;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top, #eef2ff, #ffffff);
-  color: #111827;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.12), transparent 40%),
+    linear-gradient(160deg, #020617 0%, #0f172a 45%, #020617 100%);
+  color: #e2e8f0;
 }
 
-main {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 2.5rem 1.5rem 4rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+code {
+  font-family:
+    'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
-h1,
-h2,
-h3 {
-  font-weight: 700;
-}
-
-p {
-  max-width: 65ch;
-}
-
-.visually-hidden {
+.visually-hidden,
+.sr-only {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -46,260 +44,69 @@ p {
   border: 0;
 }
 
-.api-note {
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  background: rgba(15, 118, 110, 0.15);
-  border: 1px solid rgba(15, 118, 110, 0.2);
-}
-
-.mode-selector {
-  padding: 1.25rem 1.5rem;
-  border-radius: 1rem;
-  background: rgba(15, 118, 110, 0.08);
-  border: 1px solid rgba(15, 118, 110, 0.18);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.mode-options {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.mode-option {
-  display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
-  padding: 0.75rem 1rem;
-  border-radius: 0.9rem;
-  background: rgba(255, 255, 255, 0.75);
-  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.06);
-  border: 1px solid rgba(15, 118, 110, 0.2);
-}
-
-.mode-option input[type='radio'] {
-  margin-top: 0.25rem;
-  transform: scale(1.1);
-}
-
-.mode-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.mode-name {
-  font-weight: 700;
-  color: #0f766e;
-}
-
-.mode-description {
-  font-size: 0.95rem;
-  color: rgba(17, 24, 39, 0.72);
-}
-
-button {
-  padding: 0.6rem 1.25rem;
-  border-radius: 999px;
-  border: none;
-  background: #4f46e5;
-  color: white;
-  font-size: 1rem;
-  cursor: pointer;
-  transition:
-    background 0.2s ease-in-out,
-    transform 0.1s ease-in-out;
-}
-
-button:hover:not(:disabled) {
-  background: #4338ca;
-}
-
-button:active:not(:disabled) {
-  transform: translateY(1px);
-}
-
-button:disabled {
-  opacity: 0.7;
-  cursor: default;
-}
-
-.message-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: 1rem;
-  background: rgba(79, 70, 229, 0.08);
-  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.12);
-}
-
-.message-controls {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.message-controls input[type='text'] {
-  flex: 1 1 260px;
-  padding: 0.6rem 1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(79, 70, 229, 0.35);
-  font-size: 1rem;
-}
-
-.message-controls input[type='text']:disabled {
-  background: rgba(255, 255, 255, 0.6);
-  color: rgba(17, 24, 39, 0.6);
-}
-
-.hint {
-  margin: 0;
-  color: #4c1d95;
-  font-size: 0.95rem;
-}
-
-.results {
-  padding: 1.5rem;
-  border-radius: 1.25rem;
-  background: rgba(79, 70, 229, 0.08);
-  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.12);
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.results dl {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1rem;
-  margin: 0;
-}
-
-.results dt {
-  font-weight: 600;
-  color: #312e81;
-}
-
-.results dd {
-  margin: 0.25rem 0 0;
-  font-size: 1.125rem;
-}
-
-.chat {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.messages {
-  min-height: 140px;
-  max-height: 320px;
-  overflow-y: auto;
-  padding: 1rem;
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.7);
-  box-shadow: inset 0 1px 4px rgba(15, 23, 42, 0.12);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.messages-empty {
-  margin: 0;
-  color: rgba(15, 23, 42, 0.6);
-  font-size: 0.9rem;
-  text-align: center;
-}
-
-.message {
+.stat-card {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  font-size: 0.95rem;
-  max-width: min(520px, 85%);
+  border-radius: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.12), rgba(15, 118, 110, 0.08));
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
 }
 
-.message.user {
-  margin-left: auto;
-  align-items: flex-end;
-}
-
-.message-role {
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  color: #4f46e5;
-  text-transform: uppercase;
-}
-
-.message.user .message-role {
-  color: #0f766e;
-}
-
-.message.gpt-ws .message-role,
-.message.gpt-webrtc .message-role {
-  color: #7c3aed;
-}
-
-.message.error .message-role {
-  color: #b91c1c;
-}
-
-.message-bubble {
-  padding: 0.75rem 1rem;
-  border-radius: 1rem;
-  background: rgba(79, 70, 229, 0.1);
-  border: 1px solid rgba(79, 70, 229, 0.18);
-  color: #1f2937;
-  width: 100%;
-  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.15);
-}
-
-.message.user .message-bubble {
-  background: rgba(15, 118, 110, 0.12);
-  border-color: rgba(15, 118, 110, 0.2);
-  color: #064e3b;
-  box-shadow: 0 8px 18px rgba(15, 118, 110, 0.12);
-}
-
-.message.error .message-bubble {
-  background: rgba(185, 28, 28, 0.1);
-  border-color: rgba(185, 28, 28, 0.2);
-  color: #7f1d1d;
-  box-shadow: 0 8px 18px rgba(185, 28, 28, 0.1);
-}
-
-.message-text {
+.stat-card h3 {
   margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
 }
 
-.notes {
-  margin-top: 1rem;
-  padding: 1.5rem;
-  border-radius: 1rem;
-  background: rgba(15, 118, 110, 0.1);
+.stat-value {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #f8fafc;
 }
 
-.notes li + li {
-  margin-top: 0.75rem;
+.chat-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(125, 211, 252, 0.5) transparent;
 }
 
-@media (max-width: 640px) {
-  main {
-    padding: 2rem 1rem 3rem;
+.chat-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+
+.chat-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-scroll::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.45), rgba(59, 130, 246, 0.45));
+  border-radius: 999px;
+}
+
+.chat-scroll::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.6), rgba(2, 132, 199, 0.65));
+}
+
+.message-role-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 768px) {
+  header > div {
+    padding-inline: 1.25rem;
   }
 
-  .message-controls {
-    flex-direction: column;
-  }
-
-  .message-controls input[type='text'] {
-    flex: 1 1 auto;
-    width: 100%;
+  .stat-card {
+    border-radius: 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS and rebuild the realtime lab UI with a dual navigation layout and embedded chat input
- adjust realtime event payloads so WebRTC text chats omit unsupported audio parameters while keeping WebSocket audio streaming
- harden the WebSocket bridge with injectable dependencies and add comprehensive Jest coverage for WebRTC token issuance and WebSocket flows

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e5d9e9397083269b4ace71bdf9117b