### PR TITLE
feat: 語言選擇與主題切換強化即時聊天室

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,12 +9,6 @@
       tailwind.config = {
         theme: {
           extend: {
-            colors: {
-              surface: {
-                DEFAULT: '#0b1120',
-                muted: '#111c34',
-              },
-            },
             fontFamily: {
               sans: ['"Noto Sans TC"', '"Segoe UI"', 'system-ui', 'sans-serif'],
             },
@@ -24,125 +18,129 @@
     </script>
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body class="bg-surface text-slate-100">
-    <div id="app" class="min-h-screen">
-      <div class="flex min-h-screen flex-col">
-        <header class="border-b border-slate-800/60 bg-slate-900/50 backdrop-blur">
-          <div
-            class="mx-auto flex w-full max-w-[1400px] flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between"
-          >
-            <div class="space-y-2">
-              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-sky-400">
-                Realtime Playground
-              </p>
-              <h1 class="text-3xl font-semibold tracking-tight">GPT 即時延遲實驗室</h1>
-              <p class="max-w-2xl text-sm text-slate-400">
-                按下
-                <strong class="font-semibold text-slate-100">連線</strong>
-                前先選擇傳輸模式。 成功建立連線後便能在同一個聊天面板中比較 WebSocket 與
-                WebRTC 的往返延遲。
+  <body>
+    <div id="app" class="app-shell">
+      <header class="app-header">
+        <div class="app-header__inner">
+          <div class="app-header__content">
+            <div class="app-title-group">
+              <span class="eyebrow">Realtime Playground</span>
+              <h1 class="page-title">GPT 即時延遲實驗室</h1>
+              <p class="body-muted">
+                建議先挑選傳輸模式與回覆語言，再按下「連線」。成功建立連線後即可在同一個聊天面板中比較
+                WebSocket 與 WebRTC 的往返延遲表現。
               </p>
             </div>
-            <div
-              class="rounded-2xl border border-slate-800/70 bg-slate-900/60 px-5 py-4 text-xs text-slate-400 shadow-lg shadow-slate-950/40"
-            >
-              <p>
-                範例伺服器需在環境變數中設定
-                <code class="font-mono text-slate-200">OPENAI_API_KEY</code>
-                才能代理請求；缺少金鑰時，所選模式會立即回報錯誤。
-              </p>
+            <div class="header-actions">
+              <button
+                type="button"
+                class="ghost-button"
+                @click="toggleTheme"
+                :aria-pressed="isDarkTheme"
+              >
+                <span aria-hidden="true">{{ isDarkTheme ? '🌙' : '🌞' }}</span>
+                <span>{{ themeToggleLabel }}</span>
+              </button>
             </div>
           </div>
-        </header>
+          <div class="callout">
+            範例伺服器必須在環境變數中設定
+            <code>OPENAI_API_KEY</code>
+            才能代理請求；若缺少金鑰，所選模式會立即回報錯誤並停止連線。
+          </div>
+        </div>
+      </header>
 
-        <div class="mx-auto flex w-full max-w-[1400px] flex-1 flex-col lg:flex-row">
-          <aside
-            class="border-b border-slate-800/60 bg-slate-900/30 px-6 py-6 backdrop-blur lg:h-[calc(100vh-6rem)] lg:w-80 lg:border-b-0 lg:border-r lg:px-8 lg:py-10"
-          >
-            <div class="space-y-6">
-              <section class="space-y-4">
-                <h2 class="text-lg font-semibold text-slate-200">選擇通話模式</h2>
-                <fieldset class="space-y-4">
-                  <legend class="visually-hidden">可用的連線模式</legend>
-                  <div class="flex flex-col gap-3">
-                    <label
-                      v-for="option in modeOptions"
-                      :key="option.id"
-                      class="group flex cursor-pointer items-start gap-3 rounded-2xl border border-slate-800/70 bg-slate-900/40 px-4 py-3 text-left shadow-sm transition hover:border-sky-500/60 hover:bg-slate-900/60"
-                    >
-                      <input
-                        type="radio"
-                        name="mode"
-                        :value="option.id"
-                        v-model="selectedMode"
-                        class="mt-1 h-5 w-5 border-slate-600 text-sky-400 focus:ring-sky-500"
-                      />
-                      <span class="flex-1 space-y-1">
-                        <span class="block text-base font-medium text-slate-100"
-                          >{{ option.label }}</span
-                        >
-                        <span class="block text-sm text-slate-400"
-                          >{{ option.description }}</span
-                        >
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-                <p
-                  class="rounded-xl border border-slate-800/70 bg-slate-900/40 px-4 py-3 text-xs text-slate-400"
+      <div class="app-layout">
+        <aside class="app-sidebar">
+          <section class="sidebar-section">
+            <h2 class="section-heading">選擇傳輸模式</h2>
+            <p class="section-subtle">切換後會自動結束目前的連線並清除統計資料。</p>
+            <fieldset>
+              <legend class="visually-hidden">可用的連線模式</legend>
+              <div class="mode-list">
+                <label v-for="option in modeOptions" :key="option.id" class="mode-option">
+                  <input
+                    type="radio"
+                    name="mode"
+                    :value="option.id"
+                    v-model="selectedMode"
+                  />
+                  <span class="mode-option__label">
+                    <span class="mode-option__title">{{ option.label }}</span>
+                    <span class="mode-option__description">{{ option.description }}</span>
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+            <p class="note-card">切換模式後記得重新按下「連線」。</p>
+          </section>
+
+          <section class="sidebar-section">
+            <h2 class="section-heading">回覆語言</h2>
+            <p class="section-subtle">套用於下一則訊息，可立即與 GPT 練習多國語言。</p>
+            <label class="select-wrapper">
+              <span class="sr-only">選擇回覆語言</span>
+              <select v-model="selectedLanguageId">
+                <option
+                  v-for="option in languageOptions"
+                  :key="option.id"
+                  :value="option.id"
                 >
-                  切換模式會立即結束目前的連線，需要重新按下「連線」。
-                </p>
-              </section>
+                  {{ option.label }}
+                </option>
+              </select>
+            </label>
+            <p class="language-hint">{{ activeLanguage.description }}</p>
+          </section>
 
-              <section class="space-y-3">
-                <h2 class="text-lg font-semibold text-slate-200">連線控制</h2>
-                <button
-                  id="start"
-                  type="button"
-                  class="flex w-full items-center justify-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold tracking-wide text-slate-950 shadow-lg shadow-sky-900/50 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300"
-                  @click="onStartClick"
-                  :disabled="startDisabled"
-                >
-                  {{ startLabel }}
-                </button>
-                <p class="text-xs leading-relaxed text-slate-400">
-                  {{ activeModeLabel }}
-                  會保持唯一通道。重新連線時會清除未完成的延遲樣本並重新建立連線。
-                </p>
-              </section>
-
-              <section class="space-y-3 text-sm text-slate-400">
-                <h2 class="text-lg font-semibold text-slate-200">操作提示</h2>
-                <ul class="space-y-2">
-                  <li class="flex gap-2">
-                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-sky-400"></span>
-                    <span
-                      >WebRTC
-                      需要麥克風權限才能傳輸即時語音；若拒絕權限，系統會自動改為僅接收。</span
-                    >
-                  </li>
-                  <li class="flex gap-2">
-                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
-                    <span
-                      >傳送訊息後可觀察最新延遲、平均延遲與樣本數，協助比較不同傳輸模式。</span
-                    >
-                  </li>
-                  <li class="flex gap-2">
-                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-rose-400"></span>
-                    <span>錯誤訊息會直接出現在聊天面板中，方便排除故障。</span>
-                  </li>
-                </ul>
-              </section>
-            </div>
-          </aside>
-
-          <main
-            class="flex-1 bg-slate-950/40 px-6 pb-10 pt-6 lg:h-[calc(100vh-6rem)] lg:overflow-y-auto lg:px-10 lg:pb-14 lg:pt-10"
-          >
-            <section
-              class="grid gap-4 rounded-3xl border border-slate-800/60 bg-slate-900/30 p-6 shadow-inner shadow-slate-950/40 backdrop-blur lg:grid-cols-4"
+          <section class="sidebar-section">
+            <h2 class="section-heading">連線控制</h2>
+            <button
+              id="start"
+              type="button"
+              class="primary-button"
+              @click="onStartClick"
+              :disabled="startDisabled"
             >
+              {{ startLabel }}
+            </button>
+            <p class="section-subtle">
+              {{ activeModeLabel }}
+              會保持唯一通道；重新連線時會清除尚未完成的延遲樣本並重新建立管道。
+            </p>
+            <p class="warning-text">
+              WebSocket 模式目前僅支援文字互動，如需即時語音請改用 WebRTC。
+            </p>
+          </section>
+
+          <section class="sidebar-section">
+            <h2 class="section-heading">操作提示</h2>
+            <ul class="tip-list">
+              <li class="tip-item">
+                <span class="tip-marker" aria-hidden="true"></span>
+                <span
+                  >WebRTC
+                  需要麥克風權限才能傳輸即時語音；若拒絕權限，系統會自動改為僅接收。</span
+                >
+              </li>
+              <li class="tip-item">
+                <span class="tip-marker" aria-hidden="true"></span>
+                <span
+                  >傳送訊息後可觀察最新延遲、平均延遲與樣本數，協助比較不同傳輸模式。</span
+                >
+              </li>
+              <li class="tip-item">
+                <span class="tip-marker" aria-hidden="true"></span>
+                <span>錯誤訊息會直接出現在聊天面板中，方便排除故障。</span>
+              </li>
+            </ul>
+          </section>
+        </aside>
+
+        <main class="main-column">
+          <section class="stat-surface">
+            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
               <article class="stat-card">
                 <h3>狀態</h3>
                 <p class="stat-value">{{ activeTransport.status }}</p>
@@ -159,107 +157,89 @@
                 <h3>樣本數</h3>
                 <p class="stat-value">{{ activeTransport.samples }}</p>
               </article>
-            </section>
+            </div>
+          </section>
 
-            <section class="mt-6 flex h-full flex-col gap-6 lg:mt-8">
-              <div
-                class="flex flex-1 flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/50 shadow-xl shadow-slate-950/40"
-              >
-                <div
-                  class="flex flex-col gap-2 border-b border-slate-800/70 px-6 py-5 lg:flex-row lg:items-center lg:justify-between"
-                >
-                  <div>
-                    <h2 class="text-xl font-semibold text-slate-100">
-                      {{ activeModeLabel }} 聊天面板
-                    </h2>
-                    <p class="text-sm text-slate-400">
-                      所有訊息都會出現在這裡，方便直接比較兩種模式的輸出效果。
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="chat-scroll flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-6"
-                  aria-live="polite"
-                >
-                  <template v-if="activeTransport.messages.length">
-                    <div
-                      v-for="item in activeTransport.messages"
-                      :key="item.id"
-                      :class="messageContainerClass(item.role)"
-                    >
-                      <span class="message-role-label">{{ roleLabel(item.role) }}</span>
-                      <div :class="messageBubbleClass(item.role)">
-                        <p class="leading-relaxed">{{ item.text || '（等待回覆…）' }}</p>
-                      </div>
+          <section class="main-panel">
+            <div class="main-panel__header">
+              <h2 class="section-title">{{ activeModeLabel }} 聊天面板</h2>
+              <p class="body-muted">{{ activeModeDescription }}</p>
+            </div>
+            <div class="main-panel__messages">
+              <div class="chat-scroll" aria-live="polite">
+                <template v-if="activeTransport.messages.length">
+                  <div
+                    v-for="item in activeTransport.messages"
+                    :key="item.id"
+                    :class="messageContainerClass(item.role)"
+                  >
+                    <span class="message-role-label">{{ roleLabel(item.role) }}</span>
+                    <div :class="messageBubbleClass(item.role)">
+                      <p class="leading-relaxed">{{ item.text || '（等待回覆…）' }}</p>
                     </div>
-                  </template>
-                  <p
-                    v-else
-                    class="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/40 px-6 py-10 text-center text-sm text-slate-400"
-                  >
-                    尚未傳送任何訊息。請先建立連線並輸入訊息開始對話。
-                  </p>
-                </div>
-                <form
-                  id="message-form"
-                  class="border-t border-slate-800/70 bg-slate-950/40 px-6 py-5"
-                  @submit.prevent="sendMessage"
-                >
-                  <label for="message" class="sr-only"
-                    >{{ activeModeLabel }} 準備就緒後，傳訊給 GPT</label
-                  >
-                  <div class="flex flex-col gap-3 lg:flex-row lg:items-center">
-                    <input
-                      id="message"
-                      ref="messageInputRef"
-                      name="message"
-                      type="text"
-                      placeholder="問 GPT 一個問題…"
-                      autocomplete="off"
-                      required
-                      v-model="message"
-                      :disabled="!canSend"
-                      class="flex-1 rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-3 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/50 disabled:cursor-not-allowed disabled:bg-slate-800/40 disabled:text-slate-500"
-                    />
-                    <button
-                      id="send"
-                      type="submit"
-                      :disabled="!canSend"
-                      class="flex items-center justify-center rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold tracking-wide text-slate-950 shadow-lg shadow-sky-900/40 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-300"
-                    >
-                      送出
-                    </button>
                   </div>
-                  <p class="mt-3 text-xs text-slate-500">
-                    訊息只會送往當前選定的模式，並會記錄自送出至回覆完成的往返延遲。
-                  </p>
-                </form>
+                </template>
+                <p v-else class="empty-state">
+                  尚未傳送任何訊息。請先建立連線並輸入訊息開始對話。
+                </p>
               </div>
+            </div>
+            <form
+              id="message-form"
+              class="main-panel__form"
+              @submit.prevent="sendMessage"
+            >
+              <label for="message" class="sr-only">
+                {{ activeModeLabel }} 準備就緒後，傳訊給 GPT
+              </label>
+              <div class="form-actions">
+                <input
+                  id="message"
+                  ref="messageInputRef"
+                  name="message"
+                  type="text"
+                  placeholder="問 GPT 一個問題…"
+                  autocomplete="off"
+                  required
+                  v-model="message"
+                  :disabled="!canSend"
+                  class="input-field"
+                />
+                <button
+                  id="send"
+                  type="submit"
+                  :disabled="!canSend"
+                  class="primary-button"
+                >
+                  送出
+                </button>
+              </div>
+              <p class="helper-text">
+                訊息只會送往當前選定的模式，並會記錄自送出至回覆完成的往返延遲。
+              </p>
+            </form>
+          </section>
 
-              <section
-                class="rounded-3xl border border-slate-800/60 bg-slate-900/40 p-6 text-sm text-slate-300 shadow-inner shadow-slate-950/40"
-              >
-                <h2 class="text-lg font-semibold text-slate-100">運作流程</h2>
-                <ol class="mt-4 space-y-3 list-decimal pl-6">
-                  <li>
-                    伺服器會將 WebSocket 連線代理至 OpenAI 的
-                    <code class="font-mono text-slate-200">/v1/realtime</code>
-                    端點，並能簽發瀏覽器使用的 WebRTC 短效金鑰。
-                  </li>
-                  <li>
-                    當你送出訊息時，所選模式會發送
-                    <code class="font-mono text-slate-200">response.create</code>
-                    事件，讓 GPT 收到你的提示並開始串流回覆。
-                  </li>
-                  <li>
-                    頁面會記錄每次請求的時間點，直到 GPT
-                    宣告回覆完成為止，並即時更新延遲儀表板。
-                  </li>
-                </ol>
-              </section>
-            </section>
-          </main>
-        </div>
+          <section class="info-panel">
+            <h2>運作流程</h2>
+            <ol>
+              <li>
+                伺服器會將 WebSocket 連線代理至 OpenAI 的
+                <code>/v1/realtime</code>
+                端點，並能簽發瀏覽器使用的 WebRTC 短效金鑰。
+              </li>
+              <li>
+                當你送出訊息時，所選模式會發送
+                <code>response.create</code>
+                事件，讓 GPT 收到你的提示並開始串流回覆。
+              </li>
+              <li>
+                頁面會記錄每次請求的時間點，直到 GPT
+                宣告回覆完成為止，並即時更新延遲儀表板。
+              </li>
+            </ol>
+          </section>
+        </main>
       </div>
     </div>
     <script src="app.js" type="module"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,5 +1,5 @@
 :root {
-  color-scheme: dark;
+  color-scheme: light;
   font-family:
     'Noto Sans TC',
     'Segoe UI',
@@ -7,8 +7,69 @@
     -apple-system,
     BlinkMacSystemFont,
     sans-serif;
-  background-color: #020617;
   line-height: 1.6;
+  --bg-canvas: #f6f8fa;
+  --bg-subtle: #ffffff;
+  --bg-muted: #f0f3f6;
+  --panel-border: #d0d7de;
+  --panel-border-muted: #d8dee4;
+  --text-primary: #24292f;
+  --text-secondary: #57606a;
+  --text-tertiary: #6e7781;
+  --accent: #0969da;
+  --accent-strong: #0550ae;
+  --accent-soft: #ddf4ff;
+  --shadow-sm: 0 1px 0 rgba(27, 31, 36, 0.04);
+  --shadow-lg: 0 18px 40px rgba(140, 149, 159, 0.3);
+  --header-bg: rgba(255, 255, 255, 0.9);
+  --sidebar-bg: rgba(255, 255, 255, 0.95);
+  --main-bg: rgba(255, 255, 255, 0.96);
+  --stat-bg: #f6f8fa;
+  --bubble-user-bg: #ddf4ff;
+  --bubble-user-border: #54aeff;
+  --bubble-user-text: #0a3069;
+  --bubble-assistant-bg: #ffffff;
+  --bubble-assistant-border: #d0d7de;
+  --bubble-assistant-text: #24292f;
+  --bubble-error-bg: #ffebe9;
+  --bubble-error-border: #ff8182;
+  --bubble-error-text: #cf222e;
+  --badge-bg: #eaeef2;
+  --border-strong: #afb8c1;
+  --callout-bg: #eaeef2;
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+  --bg-canvas: #0d1117;
+  --bg-subtle: #0d1117;
+  --bg-muted: #161b22;
+  --panel-border: #30363d;
+  --panel-border-muted: #30363d;
+  --text-primary: #f0f6fc;
+  --text-secondary: #c9d1d9;
+  --text-tertiary: #8b949e;
+  --accent: #4493f8;
+  --accent-strong: #1f6feb;
+  --accent-soft: rgba(68, 147, 248, 0.18);
+  --shadow-sm: 0 1px 0 rgba(1, 4, 9, 0.25);
+  --shadow-lg: 0 24px 48px rgba(1, 4, 9, 0.55);
+  --header-bg: rgba(13, 17, 23, 0.88);
+  --sidebar-bg: rgba(22, 27, 34, 0.92);
+  --main-bg: rgba(13, 17, 23, 0.92);
+  --stat-bg: #161b22;
+  --bubble-user-bg: rgba(31, 111, 235, 0.22);
+  --bubble-user-border: #1f6feb;
+  --bubble-user-text: #c6dfff;
+  --bubble-assistant-bg: #161b22;
+  --bubble-assistant-border: #30363d;
+  --bubble-assistant-text: #c9d1d9;
+  --bubble-error-bg: rgba(176, 44, 73, 0.28);
+  --bubble-error-border: #f78166;
+  --bubble-error-text: #ffdcd7;
+  --badge-bg: rgba(110, 118, 129, 0.32);
+  --border-strong: #484f58;
+  --callout-bg: rgba(32, 37, 43, 0.95);
 }
 
 * {
@@ -18,21 +79,40 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background:
-    radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.12), transparent 40%),
-    linear-gradient(160deg, #020617 0%, #0f172a 45%, #020617 100%);
-  color: #e2e8f0;
+  background: var(--bg-canvas);
+  color: var(--text-primary);
+  font-family:
+    'Noto Sans TC',
+    'Segoe UI',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  color: var(--accent-strong);
 }
 
 code {
   font-family:
     'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;
+  background: var(--bg-muted);
+  border-radius: 6px;
+  padding: 0.2rem 0.45rem;
+  border: 1px solid var(--panel-border-muted);
 }
 
-.visually-hidden,
-.sr-only {
+.sr-only,
+.visually-hidden {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -44,69 +124,572 @@ code {
   border: 0;
 }
 
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: var(--header-bg);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.app-header__inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.app-header__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .app-header__content {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+}
+
+.app-title-group {
+  max-width: 48rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(2rem, 2.6vw, 2.75rem);
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.body-muted {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.97rem;
+  line-height: 1.7;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ghost-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  outline: none;
+}
+
+.callout {
+  border-radius: 18px;
+  border: 1px solid var(--panel-border);
+  background: var(--callout-bg);
+  color: var(--text-secondary);
+  padding: 1rem 1.25rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.app-layout {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem 1.5rem 3rem;
+}
+
+@media (min-width: 1024px) {
+  .app-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.app-sidebar {
+  background: var(--sidebar-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+@media (min-width: 1024px) {
+  .app-sidebar {
+    width: 20rem;
+    flex-shrink: 0;
+  }
+}
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-heading {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.section-subtle {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.mode-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mode-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border-radius: 18px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg-subtle);
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+  cursor: pointer;
+}
+
+.mode-option:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.mode-option input[type='radio'] {
+  margin-top: 0.2rem;
+  accent-color: var(--accent);
+}
+
+.mode-option__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.mode-option__title {
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mode-option__description {
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+}
+
+.note-card {
+  border-radius: 16px;
+  border: 1px dashed var(--panel-border);
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  padding: 0.85rem 1rem;
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.select-wrapper {
+  position: relative;
+  display: inline-flex;
+  width: 100%;
+}
+
+.select-wrapper::after {
+  content: '▾';
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--text-secondary);
+}
+
+.input-field,
+.select-wrapper select {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--panel-border);
+  background: var(--bg-subtle);
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  appearance: none;
+}
+
+[data-theme='dark'] .input-field,
+[data-theme='dark'] .select-wrapper select {
+  background: var(--bg-muted);
+}
+
+.input-field::placeholder {
+  color: var(--text-tertiary);
+}
+
+.input-field:focus,
+.select-wrapper select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+.input-field:disabled,
+.select-wrapper select:disabled {
+  color: var(--text-tertiary);
+  background: var(--bg-muted);
+  cursor: not-allowed;
+}
+
+.primary-button {
+  border: none;
+  border-radius: 14px;
+  background: var(--accent);
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 4px 12px rgba(9, 105, 218, 0.25);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  background: var(--accent-strong);
+  outline: none;
+}
+
+.primary-button:disabled {
+  background: var(--border-strong);
+  color: var(--text-tertiary);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.tip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.tip-item {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.tip-marker {
+  flex-shrink: 0;
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-top: 0.4rem;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.tip-item:nth-child(2) .tip-marker {
+  background: #2da44e;
+}
+
+.tip-item:nth-child(3) .tip-marker {
+  background: #f78166;
+}
+
+[data-theme='dark'] .tip-item:nth-child(2) .tip-marker {
+  background: #3fb950;
+}
+
+[data-theme='dark'] .tip-item:nth-child(3) .tip-marker {
+  background: #ff9b8f;
+}
+
+.main-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.stat-surface {
+  border-radius: 24px;
+  border: 1px solid var(--panel-border);
+  background: var(--main-bg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
 .stat-card {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  border-radius: 1.5rem;
+  border-radius: 18px;
   padding: 1rem 1.25rem;
-  background: linear-gradient(160deg, rgba(14, 165, 233, 0.12), rgba(15, 118, 110, 0.08));
-  border: 1px solid rgba(94, 234, 212, 0.18);
-  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+  background: var(--stat-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--shadow-sm);
 }
 
 .stat-card h3 {
   margin: 0;
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: 0.75rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.7);
+  font-weight: 600;
+  color: var(--text-tertiary);
 }
 
 .stat-value {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 1.6rem;
   font-weight: 600;
-  color: #f8fafc;
+  color: var(--text-primary);
+}
+
+.main-panel {
+  border-radius: 28px;
+  border: 1px solid var(--panel-border);
+  background: var(--main-bg);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.main-panel__header {
+  padding: 1.5rem 1.75rem 1.25rem;
+  border-bottom: 1px solid var(--panel-border-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.main-panel__messages {
+  flex: 1;
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .chat-scroll {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow-y: auto;
+  padding: 1.75rem;
   scrollbar-width: thin;
-  scrollbar-color: rgba(125, 211, 252, 0.5) transparent;
+  scrollbar-color: color-mix(in srgb, var(--accent) 45%, transparent)
+    color-mix(in srgb, var(--bg-muted) 80%, transparent);
 }
 
 .chat-scroll::-webkit-scrollbar {
   width: 10px;
 }
 
+.chat-scroll::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 65%, transparent) 0%,
+    color-mix(in srgb, var(--accent) 35%, transparent) 100%
+  );
+}
+
 .chat-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.chat-scroll::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(14, 165, 233, 0.45), rgba(59, 130, 246, 0.45));
-  border-radius: 999px;
+.message-bubble {
+  border: 1px solid var(--panel-border);
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
 }
 
-.chat-scroll::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(180deg, rgba(56, 189, 248, 0.6), rgba(2, 132, 199, 0.65));
+.message-bubble--user {
+  background: var(--bubble-user-bg);
+  border-color: var(--bubble-user-border);
+  color: var(--bubble-user-text);
+}
+
+.message-bubble--assistant {
+  background: var(--bubble-assistant-bg);
+  border-color: var(--bubble-assistant-border);
+  color: var(--bubble-assistant-text);
+}
+
+.message-bubble--error {
+  background: var(--bubble-error-bg);
+  border-color: var(--bubble-error-border);
+  color: var(--bubble-error-text);
 }
 
 .message-role-label {
   font-size: 0.75rem;
-  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  font-weight: 600;
+  color: var(--text-tertiary);
 }
 
-@media (max-width: 768px) {
-  header > div {
-    padding-inline: 1.25rem;
-  }
+.main-panel__form {
+  border-top: 1px solid var(--panel-border-muted);
+  background: var(--bg-subtle);
+  padding: 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
 
-  .stat-card {
-    border-radius: 1.25rem;
+.form-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 1024px) {
+  .form-actions {
+    flex-direction: row;
+    align-items: center;
   }
+}
+
+.helper-text {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-tertiary);
+}
+
+.info-panel {
+  border-radius: 24px;
+  border: 1px solid var(--panel-border);
+  background: var(--main-bg);
+  padding: 1.75rem;
+  box-shadow: var(--shadow-sm);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.info-panel h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.info-panel ol {
+  margin: 1.2rem 0 0;
+  padding-left: 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.info-panel li {
+  line-height: 1.7;
+}
+
+.empty-state {
+  border: 1px dashed var(--panel-border);
+  border-radius: 20px;
+  background: var(--bg-muted);
+  color: var(--text-tertiary);
+  text-align: center;
+  padding: 3rem 1.5rem;
+  font-size: 0.92rem;
+}
+
+.language-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-tertiary);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: var(--badge-bg);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.warning-text {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
 }


### PR DESCRIPTION
## Summary
- 新增多語回覆選擇器並於 WebSocket/WebRTC 傳輸時帶入系統提示，避免 WebSocket 模式請求音訊造成錯誤
- 新增可記憶的亮暗主題切換，並以 GitHub 風格重新定義色彩與訊息氣泡
- 重構側邊欄與聊天面板結構，消除雙重滾動並增添 WebSocket 限制提醒

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e5eb9e60108326ac716d223bd25564