### PR TITLE
強化 WebSocket 即時語音互動

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -110,7 +110,7 @@
               會保持唯一通道；重新連線時會清除尚未完成的延遲樣本並重新建立管道。
             </p>
             <p class="warning-text">
-              WebSocket 模式目前僅支援文字互動，如需即時語音請改用 WebRTC。
+              WebSocket 模式可直接錄音並取得語音回覆，若需要瀏覽器直連可改用 WebRTC。
             </p>
           </section>
 
@@ -120,8 +120,8 @@
               <li class="tip-item">
                 <span class="tip-marker" aria-hidden="true"></span>
                 <span
-                  >WebRTC
-                  需要麥克風權限才能傳輸即時語音；若拒絕權限，系統會自動改為僅接收。</span
+                  >WebSocket 與 WebRTC
+                  都需要麥克風權限才能傳輸語音；若拒絕權限，系統會自動改為僅接收。</span
                 >
               </li>
               <li class="tip-item">
@@ -218,6 +218,30 @@
                 訊息只會送往當前選定的模式，並會記錄自送出至回覆完成的往返延遲。
               </p>
             </form>
+
+            <div class="voice-controls" v-if="selectedMode === 'ws'">
+              <div class="voice-controls__buttons">
+                <button
+                  type="button"
+                  class="secondary-button"
+                  @click="startVoiceRecording"
+                  :disabled="!ws.isReady || ws.isRecording"
+                >
+                  {{ ws.isRecording ? '錄音中…' : '開始錄音' }}
+                </button>
+                <button
+                  type="button"
+                  class="danger-button"
+                  @click="stopVoiceRecording"
+                  :disabled="!ws.isRecording"
+                >
+                  停止錄音並送出
+                </button>
+              </div>
+              <p class="helper-text">
+                錄音期間會持續串流至伺服器；按下停止後會自動將音訊送交 GPT 產生語音回覆。
+              </p>
+            </div>
           </section>
 
           <section class="info-panel">

--- a/public/styles.css
+++ b/public/styles.css
@@ -220,6 +220,14 @@ code {
   outline: none;
 }
 
+.ghost-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: transparent;
+  color: var(--text-tertiary);
+  border-color: transparent;
+}
+
 .callout {
   border-radius: 18px;
   border: 1px solid var(--panel-border);
@@ -422,6 +430,78 @@ code {
   color: var(--text-tertiary);
   cursor: not-allowed;
   box-shadow: none;
+}
+
+.secondary-button {
+  border-radius: 14px;
+  border: 1px solid var(--accent);
+  background: var(--bg-subtle);
+  color: var(--accent-strong);
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.secondary-button:disabled {
+  border-color: var(--panel-border);
+  color: var(--text-tertiary);
+  background: var(--bg-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.danger-button {
+  border-radius: 14px;
+  border: 1px solid #cf222e;
+  background: #cf222e;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 4px 12px rgba(207, 34, 46, 0.25);
+}
+
+.danger-button:hover,
+.danger-button:focus-visible {
+  background: #b31826;
+  outline: none;
+}
+
+.danger-button:disabled {
+  background: rgba(207, 34, 46, 0.4);
+  border-color: rgba(207, 34, 46, 0.4);
+  color: var(--text-tertiary);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.voice-controls {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.voice-controls__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .tip-list {


### PR DESCRIPTION
## Summary
- 新增瀏覽器端 PCM16 編碼流程，支援透過 WebSocket 串流語音並同步請求語音回覆
- 介面增加語音錄製控制按鈕與狀態提示，並自動播放模型回傳的語音音訊
- 伺服器在建立即時連線時送出語音設定，啟用 Whisper 轉寫與語音輸出

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e6085be408832680d69ee5f94c4355