### PR TITLE
修正 WebRTC 資料通道訊息格式

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -439,6 +439,7 @@ function buildResponseCreateEvent(text, clientMessageId, options = {}) {
 
   if (language?.prompt) {
     input.push({
+      type: 'message',
       role: 'system',
       content: [
         {
@@ -450,6 +451,7 @@ function buildResponseCreateEvent(text, clientMessageId, options = {}) {
   }
 
   input.push({
+    type: 'message',
     role: 'user',
     content: [
       {


### PR DESCRIPTION
## Summary
- 在建立 `response.create` 事件時補上 `type: "message"` 欄位，符合最新 Realtime WebRTC 輸入規格，避免缺少參數錯誤。

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e60d4028688326988defc9867d336e