### PR TITLE
重構即時伺服器模組化

### DIFF
--- a/src/openai/createDefaultRealtimeClient.js
+++ b/src/openai/createDefaultRealtimeClient.js
@@ -1,0 +1,48 @@
+const { OPENAI_REALTIME_BASE_URL } = require('../config/constants');
+
+function ensureFetch(fetchImpl) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('環境缺少 fetch 實作');
+  }
+  return fetchImpl;
+}
+
+function createDefaultRealtimeClient(options) {
+  const { apiKey, fetchImpl, realtimeBaseUrl = OPENAI_REALTIME_BASE_URL } = options;
+  const fetch = ensureFetch(fetchImpl ?? global.fetch);
+
+  return {
+    realtime: {
+      clientSecrets: {
+        async create(sessionConfig) {
+          const response = await fetch(`${realtimeBaseUrl}/sessions`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(sessionConfig),
+          });
+
+          if (!response.ok) {
+            let errorBody;
+            try {
+              errorBody = await response.json();
+            } catch (_error) {
+              errorBody = { message: 'OpenAI 服務回應格式錯誤' };
+            }
+
+            const error = new Error('建立短效會話失敗');
+            error.status = response.status;
+            error.error = errorBody;
+            throw error;
+          }
+
+          return await response.json();
+        },
+      },
+    },
+  };
+}
+
+module.exports = { createDefaultRealtimeClient };

--- a/src/server/realtimeServer.js
+++ b/src/server/realtimeServer.js
@@ -9,17 +9,24 @@ const {
   createRealtimeWebSocketHandler,
 } = require('../websocket/createRealtimeWebSocketHandler');
 const { createUpgradeHandler } = require('./createUpgradeHandler');
+const {
+  createRealtimeSessionService,
+} = require('../services/createRealtimeSessionService');
 
 function createRealtimeServer(options = {}) {
   const config = buildConfig(options);
 
   const app = createExpressApp({ publicDirectory: config.publicDirectory });
 
-  registerEphemeralTokenRoute(app, {
-    apiKey: config.apiKey,
+  const sessionService = createRealtimeSessionService({
+    createOpenAIClient: config.createOpenAIClient,
     realtimeModel: config.realtimeModel,
     realtimeVoice: config.realtimeVoice,
-    createOpenAIClient: config.createOpenAIClient,
+  });
+
+  registerEphemeralTokenRoute(app, {
+    apiKey: config.apiKey,
+    sessionService,
   });
 
   const server = http.createServer(app);

--- a/src/services/createRealtimeSessionService.js
+++ b/src/services/createRealtimeSessionService.js
@@ -1,0 +1,72 @@
+class RealtimeSessionError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = 'RealtimeSessionError';
+    this.status = options.status;
+    this.details = options.details;
+    this.cause = options.cause;
+  }
+}
+
+function ensureCreateSession(factory) {
+  if (typeof factory !== 'function') {
+    throw new Error('OpenAI 客戶端缺少 realtime.clientSecrets.create 函式');
+  }
+  return factory;
+}
+
+function createRealtimeSessionService(dependencies) {
+  const { createOpenAIClient, realtimeModel, realtimeVoice } = dependencies;
+
+  if (typeof createOpenAIClient !== 'function') {
+    throw new Error('必須提供 createOpenAIClient 函式');
+  }
+
+  const createSessionPayload = (session) => ({
+    id: session?.id ?? null,
+    client_secret: session?.client_secret ?? null,
+    expires_at: session?.client_secret?.expires_at ?? null,
+  });
+
+  const resolveRealtimeClient = async () => {
+    try {
+      const client = await Promise.resolve(createOpenAIClient());
+      const realtime = client?.realtime;
+      const clientSecrets = realtime?.clientSecrets;
+      const create = ensureCreateSession(clientSecrets?.create);
+      return { create };
+    } catch (error) {
+      throw new RealtimeSessionError('建立 OpenAI 客戶端失敗', { cause: error });
+    }
+  };
+
+  const createSession = async () => {
+    const { create } = await resolveRealtimeClient();
+    try {
+      const session = await create({ model: realtimeModel, voice: realtimeVoice });
+      return createSessionPayload(session);
+    } catch (error) {
+      if (typeof error?.status === 'number') {
+        const details =
+          error?.error?.message ??
+          (typeof error?.message === 'string' ? error.message : undefined);
+        throw new RealtimeSessionError('建立短效會話失敗', {
+          status: error.status,
+          details,
+          cause: error,
+        });
+      }
+
+      throw new RealtimeSessionError('建立短效會話時發生錯誤', {
+        cause: error,
+      });
+    }
+  };
+
+  return { createSession };
+}
+
+module.exports = {
+  createRealtimeSessionService,
+  RealtimeSessionError,
+};


### PR DESCRIPTION
## 摘要
- 建立預設的 OpenAI Realtime 客戶端工廠並透過設定模組注入
- 新增短效金鑰服務並以依賴注入重構路由與伺服器組態
- 強化 WebSocket 處理器，延遲載入傳輸類別並傳送 session.update 事件

## 測試
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e63a599ee883268d0ddca87a8770a1